### PR TITLE
Diffuse error in H direction on scr5

### DIFF
--- a/scr5.class.php
+++ b/scr5.class.php
@@ -106,7 +106,7 @@ class Surf5 extends Surf {
 				
 				$e = array($v[0] - $_v['red'], $v[1] - $_v['green'], $v[2] - $_v['blue']);
 
-				$p = &$dither_line1[$x+1];
+				$p = &$dither_line1[$x+2];
 				$p[0] += $e[0] * 7 >> 4;
 				$p[1] += $e[1] * 7 >> 4;
 				$p[2] += $e[2] * 7 >> 4;


### PR DESCRIPTION
Screens converted in screen 5 don't seem to produce checkerboards, only alternate lines. I think that's because the error is not being spread in horizontal direction. Maybe this x+1 should have been x+2 instead? This error doesn't happen in scr2, but may be present in other screens. I have no php installed so this is untested.